### PR TITLE
webpack version update

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "url-loader": "^0.6.2"
   },
   "peerDependencies": {
-    "webpack": "^2.0.0 || ^3.0.0"
+    "webpack": "^2.0.0 || ^3.0.0 || ^4.0.0"
   },
   "devDependencies": {
     "babel-cli": "^6.24.1",


### PR DESCRIPTION
This warning was appear on yarn install : 
`warning " > sizeof-loader@1.1.0" has incorrect peer dependency "webpack@^2.0.0 || ^3.0.0".`